### PR TITLE
[FEATURE] user 메인페이지 카테고리 별 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/ohgiraffers/poppop/popupstore/controller/PopupStoreController.java
+++ b/backend/src/main/java/com/ohgiraffers/poppop/popupstore/controller/PopupStoreController.java
@@ -123,4 +123,39 @@ public class PopupStoreController {
 //        List<PopupStoreDTO> nearest = popupStoreService.selectPopupStoreNear(lat, lng, limit);
 //        return ResponseEntity.ok(nearest);
 //    }
+
+    // 팝업스토어 카테고리 집계
+    @GetMapping("/popup-stores/category")
+    public ResponseEntity<List<String>> selectAllCategory(){
+
+        List<String> categoryList = popupStoreService.selectAllCategory();
+//        System.out.println("categoryList = " + categoryList);
+
+        return ResponseEntity.ok(categoryList);
+    }
+
+    // 카테고리별 팝업스토어 조회
+    @GetMapping("/popup-stores/category/{category}")
+    public ResponseEntity<List<PopupStoreDTO>> selectPopupStoreByCategory(@PathVariable(required = false) String category){
+
+        List<PopupStoreDTO> popupList = popupStoreService.selectPopupStoreByCategory(category);
+        ArrayList<Integer> popupNo = new ArrayList<>();
+        for(PopupStoreDTO popup : popupList){
+            popupNo.add(popup.getNo());
+            System.out.println(popup.getNo());
+        }
+        // 팝업번호들
+        System.out.println(popupNo);
+
+        ArrayList<Integer> popups = new ArrayList<>();
+        for(int i =0; i<7;i++){
+            int random = (int)(Math.random()*popupNo.size());
+            int popup = popupNo.get(random);
+            popups.add(popup);
+        }
+        // 카테고리팝업에 default로 보여질 7개의 팝업번호 : popups
+        System.out.println("popups = " + popups);
+
+        return ResponseEntity.ok(popupList);
+    }
 }

--- a/backend/src/main/java/com/ohgiraffers/poppop/popupstore/model/dao/PopupStoreMapper.java
+++ b/backend/src/main/java/com/ohgiraffers/poppop/popupstore/model/dao/PopupStoreMapper.java
@@ -22,5 +22,9 @@ public interface PopupStoreMapper {
 
     List<PopupStoreDTO> selectPopupStoreRandomly(ArrayList<Integer> random);
 
+    List<String> selectAllCategory();
+
+    List<PopupStoreDTO> selectPopupStoreByCategory(String category);
+
 //    List<PopupStoreDTO> selectPopupStoreNear(double lat, double lng, int limit);
 }

--- a/backend/src/main/java/com/ohgiraffers/poppop/popupstore/model/service/PopupStoreService.java
+++ b/backend/src/main/java/com/ohgiraffers/poppop/popupstore/model/service/PopupStoreService.java
@@ -49,4 +49,12 @@ public class PopupStoreService {
     public List<PopupStoreDTO> selectPopupStoreRandomly(ArrayList<Integer> random) {
         return popupStoreMapper.selectPopupStoreRandomly(random);
     }
+
+    public List<String> selectAllCategory() {
+        return popupStoreMapper.selectAllCategory();
+    }
+
+    public List<PopupStoreDTO> selectPopupStoreByCategory(String category) {
+        return popupStoreMapper.selectPopupStoreByCategory(category);
+    }
 }

--- a/backend/src/main/resources/mappers/PopupStoreMapper.xml
+++ b/backend/src/main/resources/mappers/PopupStoreMapper.xml
@@ -21,6 +21,11 @@
         <result property="clickCount" column="click_count"/>
     </resultMap>
 
+    <!--카테고리 집계용 resultMap-->
+    <resultMap id="popupCategoryResultMap" type="String">
+        <id property="categoryName" column="category_name"/>
+    </resultMap>
+
 
     <select id="selectPopupStoreByPagePlacement" resultMap="popupStoreResultMap">
         select
@@ -121,6 +126,7 @@
         or brand_name like concat('%',#{searchWord},'%')
         or popup_location like concat('%',#{searchWord},'%')
         or h.hashtag_name like concat('%',#{searchWord},'%')
+        or category_name like concat('%',#{searchWord},'%')
         )
 
     </select>
@@ -228,4 +234,44 @@
 <!--        having distance < 50*1000-->
 <!--         order by distance;-->
 <!--    </select>-->
+
+    <!-- 카테고리 집계 -->
+    <select id="selectAllCategory" resultMap="popupCategoryResultMap">
+        select
+               distinct category_name
+               from popup_store
+               order by field(category_name,'전체') desc
+    </select>
+
+    <!--카테고리별 팝업조회-->
+    <select id="selectPopupStoreByCategory" resultMap="popupStoreResultMap">
+        select
+            popup_no,
+            popup_name,
+            brand_name,
+            popup_start_date,
+            popup_end_date,
+            open_time,
+            close_time,
+            popup_location,
+            reservable_status,
+            popup_explanation,
+            approval_status,
+            rejection_reason,
+            id,
+            click_count,
+            category_name
+            from popup_store
+<!--            where popup_no in-->
+<!--            <foreach item="popup" collection="popups" open="(" separator="," close=")">-->
+<!--                #{popup}-->
+<!--            </foreach>-->
+            <if test="category=='전체'">
+
+            </if>
+            <if test="category!=null and category!='전체'">
+                where category_name=#{category}
+            </if>
+
+    </select>
 </mapper>

--- a/frontend/src/api/PopupStoreAPI.jsx
+++ b/frontend/src/api/PopupStoreAPI.jsx
@@ -52,3 +52,15 @@ export function selectPopupRandomly(){
     return axios.get(`${BACKEND_URL}/popup-stores/random/${arr}`)
     .then(response=>response.data)
 }
+
+//팝업스토어 카테고리 집계
+export function selectAllCategory(){
+    return axios.get(`${BACKEND_URL}/popup-stores/category`)
+    .then(response => response.data)
+}
+
+//팝업스토어 카테고리별 조회
+export function selectPopupStoreByCategory(category){
+    return axios.get(`${BACKEND_URL}/popup-stores/category/${category}`)
+    .then(response=>response.data)
+}

--- a/frontend/src/componenets/pupupinfo/PopupInfo.jsx
+++ b/frontend/src/componenets/pupupinfo/PopupInfo.jsx
@@ -35,8 +35,8 @@ function PopupInfo(){
             .then(data => {
                 console.log(data)
                 setCoord({
-                    lat:data.documents[0].y,
-                    lng:data.documents[0].x
+                    lng:data.documents[0].x,
+                    lat:data.documents[0].y
                 })
                 console.log(coord)
             })

--- a/frontend/src/componenets/user/userfavorite/FavoritePopups.jsx
+++ b/frontend/src/componenets/user/userfavorite/FavoritePopups.jsx
@@ -8,7 +8,7 @@ import FPStyle from "./FP.module.css"
 function FavoritePopups(){
 
         const [popupStores, setPopupStores] = useState([])
-        const [id ,setId] = useState("gunwoo")
+        const [id ,setId] = useState("user_geonwoo")
     
         useEffect(()=>{
             selectFavoritePopupStoreById(id).then(data=>{

--- a/frontend/src/componenets/user/usermain/CategoryComp.jsx
+++ b/frontend/src/componenets/user/usermain/CategoryComp.jsx
@@ -1,9 +1,39 @@
 import { useDrag } from "react-dnd";
 import CCStyle from "./MidComp.module.css"
 import { Swiper, SwiperSlide } from "swiper/react";
+import { useEffect, useState } from "react";
+import { selectAllCategory, selectPopupStoreByCategory } from "../../../api/PopupStoreAPI";
+import PopupComp from "./PopupComp";
 
 
 function CategoryComp(){
+
+    const [categoryList, setCategoryList] = useState(["전체"])
+    const [category, setCategory] = useState("전체");
+    const [popup, setPopup] = useState([])
+
+    const onClickCategory = e => {
+        setCategory(e.target.textContent)       
+    }
+
+    useEffect(()=>{
+        selectAllCategory()
+        .then(data=>{
+            console.log("카테고리 = ",data)
+            setCategoryList(data)
+            console.log("선택된 카테고리 : ",category)
+            
+            
+        })
+    },[category])
+
+    useEffect(()=>{
+        selectPopupStoreByCategory(category)
+        .then(data=>{
+            console.log("카테고리별 팝업스토어 : ",data)
+            setPopup(data)
+        })
+    },[category])
 
 
 
@@ -11,13 +41,9 @@ function CategoryComp(){
         <>
             <div className={CCStyle.explain}>카테고리</div>
             <div className={CCStyle.categorylayout}>
-                <div className={CCStyle.category}>카테고리1</div>
-                <div className={CCStyle.category}>카테고리2</div>
-                <div className={CCStyle.category}>카테고리3</div>
-                <div className={CCStyle.category}>카테고리4</div>
-                <div className={CCStyle.category}>카테고리5</div>
-                <div className={CCStyle.category}>카테고리6</div>
-                <div className={CCStyle.category}>카테고리7</div>
+                {categoryList.map(a=><div key={a} className={CCStyle.category} onClick={onClickCategory}>{a}</div>)}
+                
+                
             </div>
             <Swiper
                 className={CCStyle.layout}
@@ -26,13 +52,8 @@ function CategoryComp(){
                 slidesOffsetAfter={200}
                 
             >
-                <SwiperSlide className={CCStyle.slide}>카테고리별 팝업</SwiperSlide>
-                <SwiperSlide className={CCStyle.slide}>카테고리별 팝업</SwiperSlide>
-                <SwiperSlide className={CCStyle.slide}>카테고리별 팝업</SwiperSlide>
-                <SwiperSlide className={CCStyle.slide}>카테고리별 팝업</SwiperSlide>
-                <SwiperSlide className={CCStyle.slide}>카테고리별 팝업</SwiperSlide>
-                <SwiperSlide className={CCStyle.slide}>카테고리별 팝업</SwiperSlide>
-                <SwiperSlide className={CCStyle.slide}>카테고리별 팝업</SwiperSlide>
+                {popup.map(popupstore=><SwiperSlide className={CCStyle.slide}><PopupComp key={popupstore.no} popupstore={popupstore}/></SwiperSlide>)}
+                
             
             </Swiper>
         </>


### PR DESCRIPTION
## ✔ 관련 이슈 번호 
#44
## 📃 작업 상세 내용 
카테고리를 pathvariable로 넘겨서 카테고리 별 팝업스토어를 랜덤으로 조회할 수 있는 api 작성하고 연동.
현재는 카테고리에 해당하는 모든 팝업스토어가 조회되지만 추후에 7개 랜덤으로 조회할 수 있도록 수정
## 📸 결과 
default
<img width="916" height="409" alt="image" src="https://github.com/user-attachments/assets/88f413ae-1b71-461e-b44e-8bfa73efd692" />
게임
<img width="907" height="399" alt="image" src="https://github.com/user-attachments/assets/5bd927a7-20df-4dbb-ab65-80ab77992bcd" />

