### PR TITLE
[FIX] user 랜덤 팝업 조회 랜덤번호 뽑기 수정

### DIFF
--- a/frontend/src/api/PopupStoreAPI.jsx
+++ b/frontend/src/api/PopupStoreAPI.jsx
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { useState } from "react";
 
 
 const restapikey = import.meta.env.VITE_KAKAOMAP_RESTAPI_KEY
@@ -41,10 +42,12 @@ export function selectFavoritePopupStoreById(id){
 }
 
 // 팝업스토어 랜덤조회
-export function selectPopupRandomly(){
+export function selectPopupRandomly(size){
+
+
     const arr = new Array();
     for(let i =arr.length;i<7;i++){
-        arr[i]=parseInt((Math.random()*50)+1)
+        arr[i]=parseInt((Math.random()*size)+1)
     }
     console.log("arr",arr)
 

--- a/frontend/src/componenets/user/usermain/MidComp.jsx
+++ b/frontend/src/componenets/user/usermain/MidComp.jsx
@@ -3,7 +3,7 @@ import MCStyle from "./MidComp.module.css"
 
 import { useState,useEffect } from "react";
 import PopupComp from "./PopupComp";
-import { selectPopupRandomly } from "../../../api/PopupStoreAPI";
+import { selectAllPopupStore, selectPopupRandomly } from "../../../api/PopupStoreAPI";
 
 
 
@@ -11,15 +11,23 @@ import { selectPopupRandomly } from "../../../api/PopupStoreAPI";
 export function MidComp1(){
 
     const [popups, setPopups] = useState([])
+    const [size, setSize] = useState();
+        
+    useEffect(()=>{
+        selectAllPopupStore()
+        .then(data=>{
+            setSize(data.length)
+        })
+    })
 
     useEffect(()=>{
-        selectPopupRandomly()
+        selectPopupRandomly(size)
         .then(data=>{
             console.log("randompopup",data)
             setPopups(data)
             
         })
-    },[])
+    },[size])
     
 
     return(
@@ -38,16 +46,24 @@ export function MidComp1(){
 }
 export function MidComp2(){
 
-        const [popups, setPopups] = useState([])
+    const [popups, setPopups] = useState([])
+    const [size, setSize] = useState();
+        
+    useEffect(()=>{
+        selectAllPopupStore()
+        .then(data=>{
+            setSize(data.length)
+        })
+    })
 
     useEffect(()=>{
-        selectPopupRandomly()
+        selectPopupRandomly(size)
         .then(data=>{
             console.log("randompopup",data)
             setPopups(data)
             
         })
-    },[])
+    },[size])
 
 
     return(

--- a/frontend/src/componenets/user/usermain/TopComp.jsx
+++ b/frontend/src/componenets/user/usermain/TopComp.jsx
@@ -5,7 +5,7 @@ import 'swiper/css/pagination';
 import "swiper/css"
 import { Autoplay, EffectCreative, Pagination } from "swiper/modules";
 import { useEffect, useState } from "react";
-import { selectPopupRandomly } from "../../../api/PopupStoreAPI";
+import { selectAllPopupStore, selectPopupRandomly } from "../../../api/PopupStoreAPI";
 import PopupComp from "./PopupComp";
 import { Link } from "react-router-dom";
 
@@ -19,14 +19,25 @@ import { Link } from "react-router-dom";
 function TopComp (){
 
     const [popups,setPopups] = useState([])
+    const [size, setSize] = useState();
 
     useEffect(()=>{
-        selectPopupRandomly()
+        selectAllPopupStore()
+        .then(data=>{
+            setSize(data.length)
+        })
+    },[])
+
+    useEffect(()=>{
+        selectPopupRandomly(size)
         .then(data=>{
             console.log("TCdata",data)
             setPopups(data)
         })
-    },[])
+    },[size])
+
+    
+    
 
     return(
         <>


### PR DESCRIPTION
## ✔ 관련 이슈 번호 
#50
## 📃 작업 상세 내용 
랜덤 팝업 조회할 때 1~50 번호로 뽑았는데 DB에 있는 1번부터 마지막번호까지의 숫자 뽑기
## 📸 결과 
랜덤 팝업스토어 조회
<img width="523" height="278" alt="image" src="https://github.com/user-attachments/assets/3226ddf6-3acd-421f-918c-81d1cc5be7e8" />
랜덤 숫자 뽑는 범위를 팝업스토어 전체 길이로 수정
<img width="306" height="331" alt="image" src="https://github.com/user-attachments/assets/5bf5ae85-3466-4254-91bc-031a926d9729" />

※useEffect()를 두번써서 promise 오류남※
<img width="648" height="212" alt="image" src="https://github.com/user-attachments/assets/3fab275f-6070-4f9f-b1b1-e8607a6abf9c" />

※ 랜덤숫자 범위 설정하는 메소드와 랜덤 팝업을 조회하는 메소드를 비동기 처리를 해야함※

