### PR TITLE
[FIX] user메인페이지 하단컴포넌트 수정

### DIFF
--- a/frontend/src/api/PopupStoreAPI.jsx
+++ b/frontend/src/api/PopupStoreAPI.jsx
@@ -42,17 +42,21 @@ export function selectFavoritePopupStoreById(id){
 }
 
 // 팝업스토어 랜덤조회
-export function selectPopupRandomly(size){
+export function selectPopupRandomly(size,length){
 
 
-    const arr = new Array();
-    for(let i =arr.length;i<7;i++){
-        arr[i]=parseInt((Math.random()*size)+1)
+    const arr = new Set();
+    for(let i =0;i<size;i=arr.size){
+        const a = parseInt((Math.random()*length)+1)
+        arr.add(a)
     }
-    console.log("arr",arr)
+    console.log(arr)
+    const arr2 = Array.from(arr)
+    console.log(arr2)
 
 
-    return axios.get(`${BACKEND_URL}/popup-stores/random/${arr}`)
+
+    return axios.get(`${BACKEND_URL}/popup-stores/random/${arr2}`)
     .then(response=>response.data)
 }
 

--- a/frontend/src/componenets/user/usermain/BotComp.jsx
+++ b/frontend/src/componenets/user/usermain/BotComp.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react"
 import BCStyle from "./MidComp.module.css"
-import { selectAllPopupStore } from "../../../api/PopupStoreAPI"
+import { selectAllPopupStore, selectPopupRandomly } from "../../../api/PopupStoreAPI"
 import PopupStores from "../../PopupStores"
+import { Link } from "react-router-dom"
+
 
 
 export function BotComp() {
@@ -9,10 +11,14 @@ export function BotComp() {
     const [popupStores, setPopupStores] = useState([])
 
     useEffect(()=>{
-        selectAllPopupStore().then(data=>{
-            console.log(data)
-            setPopupStores(data)
-        })
+        const fetchData = async () =>{
+            const data = await selectAllPopupStore()
+            const length = data.length
+
+            const data2 = await selectPopupRandomly(10,length)
+            setPopupStores(data2)
+        }
+        fetchData()
     },[])
 
 
@@ -33,6 +39,9 @@ export function BotComp() {
             <div className={BCStyle.botlayout}>
                 {popupStores.map(popupstore =><PopupStores key={popupstore.no} popupstore={popupstore}/>)}
             </div>
+            <Link to={"/user/search"}>
+                <div className={BCStyle.more}>더보기</div>
+            </Link>
         </>
     )
 }

--- a/frontend/src/componenets/user/usermain/MidComp.jsx
+++ b/frontend/src/componenets/user/usermain/MidComp.jsx
@@ -17,7 +17,7 @@ export function MidComp1(){
             const data = await selectAllPopupStore()
             const length = data.length
 
-            const data2 = await selectPopupRandomly(length)
+            const data2 = await selectPopupRandomly(7,length)
             setPopups(data2)
 
         }
@@ -48,7 +48,7 @@ export function MidComp2(){
             const data = await selectAllPopupStore()
             const length = data.length
 
-            const data2 = await selectPopupRandomly(length)
+            const data2 = await selectPopupRandomly(7,length)
             setPopups(data2)
 
         }

--- a/frontend/src/componenets/user/usermain/MidComp.module.css
+++ b/frontend/src/componenets/user/usermain/MidComp.module.css
@@ -58,3 +58,14 @@
     display: flex;
     flex-wrap: wrap;
 }
+
+.more{
+    width: 90%;
+    border: white solid 3px;
+    text-align: center;
+    position: relative;
+    left: 5%;
+    color: white;
+    text-decoration: white;
+    
+}

--- a/frontend/src/componenets/user/usermain/TopComp.jsx
+++ b/frontend/src/componenets/user/usermain/TopComp.jsx
@@ -26,7 +26,7 @@ function TopComp (){
             const length = data.length
         
 
-            const data2 = await selectPopupRandomly(length)
+            const data2 = await selectPopupRandomly(7,length)
             setPopups(data2)
         }
         fetchData();


### PR DESCRIPTION
## ✔ 관련 이슈 번호 
#49 
## 📃 작업 상세 내용 
랜덤 팝업 api 인자에 몇개의 팝업을 조회할건지 추가
중복허용하는 array로 랜덤 팝업 번호 받았을 때 설정한 개수만큼 팝업이 조회되지않아서
set으로 랜덤 팝업 번호 리스트를 받은후 array로 변환하여 조회되도록 수정 -> 같은 컴포넌트 내 중복 팝업 제거
user 메인페이지 하단컴포넌트에서 전체 팝업스토어를 조회하지 않고 랜덤한 10개의 팝업스토어를 조회하도록 수정.
더보기 버튼을 통해서 조회 페이지로 이동할 수 있도록 수정
## 📸 결과 
더보기버튼
<img width="1920" height="918" alt="image" src="https://github.com/user-attachments/assets/c302a6d5-4ecb-4c09-bfd5-a1aa1fce8ca3" />
Set -> Array로 중복 제거 및 size로 팝업 개수 제한
<img width="518" height="360" alt="image" src="https://github.com/user-attachments/assets/e3fda536-9763-4e6d-ac0b-3aa49d93162f" />
