### PR TITLE
[FEATURE] user 메인페이지 날짜별 방문 가능한 팝업 조회기능

### DIFF
--- a/backend/src/main/java/com/ohgiraffers/poppop/popupstore/controller/PopupStoreController.java
+++ b/backend/src/main/java/com/ohgiraffers/poppop/popupstore/controller/PopupStoreController.java
@@ -8,10 +8,7 @@ import org.springframework.http.ResponseEntity;import org.springframework.securi
 import org.springframework.security.core.userdetails.UserDetails;
 
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -116,10 +113,6 @@ public class PopupStoreController {
 ////            random.add(randomNo);
 ////        }
 ////        System.out.println(random);
-
-
-
-
         return ResponseEntity.ok(popupStoreService.selectPopupStoreRandomly(random));
     }
     // 내 위치랑 가까운 팝업스토어 조회
@@ -167,5 +160,12 @@ public class PopupStoreController {
         System.out.println("popups = " + popups);
 
         return ResponseEntity.ok(popupList);
+    }
+
+    // 날짜별 팝업스토어 조회
+    @GetMapping("popup-stores/date/{date}")
+    public ResponseEntity<List<PopupStoreDTO>> selectPopupByDate(@PathVariable String date){
+        System.out.println(date);
+        return ResponseEntity.ok(popupStoreService.selectPopupByDate(date));
     }
 }

--- a/backend/src/main/java/com/ohgiraffers/poppop/popupstore/model/dao/PopupStoreMapper.java
+++ b/backend/src/main/java/com/ohgiraffers/poppop/popupstore/model/dao/PopupStoreMapper.java
@@ -37,4 +37,7 @@ public interface PopupStoreMapper {
 
     int insertPopupStore(PopupStoreDTO popupStoreDTO);
 
+    List<PopupStoreDTO> selectPopupStoreRandomlyByDate(ArrayList<Integer> random, Object date);
+
+    List<PopupStoreDTO> selectPopupByDate(String date);
 }

--- a/backend/src/main/java/com/ohgiraffers/poppop/popupstore/model/service/PopupStoreService.java
+++ b/backend/src/main/java/com/ohgiraffers/poppop/popupstore/model/service/PopupStoreService.java
@@ -81,4 +81,12 @@ public class PopupStoreService {
         popupStoreMapper.insertPopupStore(dto);
     }
 
+    public List<PopupStoreDTO> selectPopupStoreRandomlyByDate(ArrayList<Integer> random, Object date) {
+        return popupStoreMapper.selectPopupStoreRandomlyByDate(random,date);
+    }
+
+
+    public List<PopupStoreDTO> selectPopupByDate(String date) {
+        return popupStoreMapper.selectPopupByDate(date);
+    }
 }

--- a/backend/src/main/resources/mappers/PopupStoreMapper.xml
+++ b/backend/src/main/resources/mappers/PopupStoreMapper.xml
@@ -256,6 +256,83 @@
         )
     </select>
 
+    <!--날짜별 팝업 조회-->
+    <select id="selectPopupByDate" resultMap="popupStoreResultMap">
+        select
+        popup_no,
+        popup_name,
+        brand_name,
+        popup_start_date,
+        popup_end_date,
+        open_time,
+        close_time,
+        popup_location,
+
+        latitude,
+        longitude,
+
+        reservable_status,
+        popup_explanation,
+        approval_status,
+        rejection_reason,
+        id,
+        click_count,
+
+        category_name,
+        advance_reservation,
+        homepage_link,
+        capacity,
+        hashtag_name
+        from popup_store
+        where popup_start_date &lt; #{date}
+        and popup_end_date &gt; #{date}
+    </select>
+
+
+    <!-- 날짜별 팝업 랜덤 조회-->
+    <select id="selectPopupStoreRandomlyByDate" resultMap="popupStoreResultMap">
+        select
+        popup_no,
+        popup_name,
+        brand_name,
+        popup_start_date,
+        popup_end_date,
+        open_time,
+        close_time,
+        popup_location,
+
+        latitude,
+        longitude,
+
+        reservable_status,
+        popup_explanation,
+        approval_status,
+        rejection_reason,
+        id,
+        click_count,
+
+        category_name,
+        advance_reservation,
+        homepage_link,
+        capacity,
+        hashtag_name
+
+        from popup_store
+        where popup_no in
+        <foreach item="popupNo" collection="random" open="(" separator="," close=")">
+            #{popupNo}
+        </foreach>
+        and popup_start_date &lt; concat(#{year},"-",#{month},"-",#{date})
+        and popup_end_date &gt; concat(#{year},"-",#{month},"-",#{date})
+        order by field(popup_no,
+        <foreach item="popupNo" collection="random" open="" separator="," close="">
+            #{popupNo}
+        </foreach>
+        )
+    </select>
+
+
+
     <!--가까운 팝업 조회-->
 <!--    위도 경도값 넣어서 계산 db 수정 후 작업-->
 <!--    <select id="selectPopupStoreNear" resultMap="popupStoreResultMap">-->

--- a/frontend/src/api/PopupStoreAPI.jsx
+++ b/frontend/src/api/PopupStoreAPI.jsx
@@ -83,3 +83,9 @@ export function selectPopupStoreByCategory(category){
     return API.get(`${BACKEND_URL}/popup-stores/category/${category}`)
     .then(response=>response.data)
 }
+
+// 날짜별 팝업스토어 조회
+export function selectPopupByDate(date){
+    return API.get(`${BACKEND_URL}/popup-stores/date/${date}`)
+    .then(response=>response.data)
+}

--- a/frontend/src/componenets/user/usermain/BotComp.jsx
+++ b/frontend/src/componenets/user/usermain/BotComp.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import BCStyle from "./MidComp.module.css"
-import { selectAllPopupStore, selectPopupRandomly } from "../../../api/PopupStoreAPI"
+import { selectAllPopupStore, selectPopupByDate, selectPopupRandomly } from "../../../api/PopupStoreAPI"
 import PopupStores from "../../PopupStores"
 import { Link } from "react-router-dom"
 
@@ -11,16 +11,64 @@ export function BotComp() {
     const [isDrag,setIsDrag] = useState(false)
     const [popupStores, setPopupStores] = useState([])
 
+    const [searchDay, setSearchDay] = useState(new Date())
+    const [classIndex, setClassIndex] = useState(0)
+
+    const todayYear = searchDay.getFullYear();
+    const todayMonth = searchDay.getMonth()+1;
+    const todayDate  = searchDay.getDate();
+    const today = todayYear + "-" + todayMonth + "-" + todayDate
+
+    const day7 = ['일','월','화','수','목','금','토']
+
+    const onClickDate = (e)=>{
+        
+    }
+    
+
+    
+    
+
+    
+
+    
+    
+    const date = [];
+    for(let i=0;i<10;i++){
+        const today = new Date()
+        today.setDate(today.getDate()+i)        
+        date.push(today)
+    }
+    
+
     useEffect(()=>{
         const fetchData = async () =>{
-            const data = await selectAllPopupStore()
-            const length = data.length
 
-            const data2 = await selectPopupRandomly(10,length)
-            setPopupStores(data2)
+            const data = await selectPopupByDate(today)
+            const length = data.length
+            console.log(length)
+            
+            
+            const popups = new Set();
+            for(let i = popups.size; i<10;i=popups.size){
+                const a = parseInt(Math.random()*length)
+                // console.log(a)
+                // console.log("size",popups.size)
+                // console.log("i",i)
+                popups.add(data[a])
+            }
+            // console.log("popups",popups)
+            const popupArray = Array.from(popups)
+            setPopupStores(popupArray)
+
+
+    
         }
         fetchData()
-    },[])
+        console.log(today)
+        console.log(classIndex)
+        
+    },[searchDay])
 
 
 
@@ -29,13 +77,12 @@ export function BotComp() {
         <>
             <div className={BCStyle.explain}>오늘 방문 가능한 팝업스토어</div>
             <div className={BCStyle.datelayout}>
-                <div className={BCStyle.date}>today</div>
-                <div className={BCStyle.date}>today+1</div>
-                <div className={BCStyle.date}>today+2</div>
-                <div className={BCStyle.date}>today+3</div>
-                <div className={BCStyle.date}>today+4</div>
-                <div className={BCStyle.date}>today+5</div>
-                <div className={BCStyle.date}>today+6</div>
+                {date.map((date, index) =><div className={classIndex===index?BCStyle.active:BCStyle.date} index={index} onClick={()=>{setSearchDay(date);setClassIndex(index)}}>
+                                    <div className={BCStyle.day}>
+                                        {(date.getDate()==new Date().getDate()) ? "today" : day7.at(date.getDay())}
+                                    </div>
+                                    <div>{date.getDate()}</div>
+                                </div>)}
             </div>
             <div className={BCStyle.botlayout}>
                 {popupStores.map(popupstore =><PopupStores key={popupstore.no} popupstore={popupstore} setIsDrag={setIsDrag} posterNo={popupstore.no}/>)}

--- a/frontend/src/componenets/user/usermain/MidComp.module.css
+++ b/frontend/src/componenets/user/usermain/MidComp.module.css
@@ -40,23 +40,44 @@
 .datelayout{
     display: flex;
     justify-content: space-around;
+    align-items: center;
     height: 100px;
     /* background-color: yellowgreen; */
 }
-
-.date{
-    width: 80px;
-    height: 80px;
+.active{
+    width: 75px;
+    height: 75px;
     background-color: red;
     border-radius: 100px;
     display: flex;
     justify-content: center;
     align-items: center;
     font-size: 16px;
+    flex-direction: column;
+    cursor: pointer;
+    border: none;
+}
+
+.date{
+    width: 60px;
+    height: 60px;
+    background-color: gray;
+    border-radius: 100px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 16px;
+    flex-direction: column;
+    cursor: pointer;
+    border: none;
+}
+.day{
+    font-size: 12px;
 }
 .botlayout{
     display: flex;
     flex-wrap: wrap;
+    
 }
 
 .more{

--- a/frontend/src/componenets/user/usermain/PopupComp.jsx
+++ b/frontend/src/componenets/user/usermain/PopupComp.jsx
@@ -38,9 +38,9 @@ function PopupComp({popupstore,posterNo}){
     return(
         <>
             
-                <Link to={`/user/${popupstore.no}`}>
+                <Link to={`/user/${popupstore.no}`} onClick={()=>{location.href(`/user/${popupstore.no}`)}}>
                 <div className={PSStyle.back}>
-                    <img src={posterUrl} alt="" className={PSStyle.img}/>
+                    <img src={posterUrl} alt={posterNo} className={PSStyle.img}/>
                     {/* <div className={PSStyle.layout} ref={drag}>
                         <div className={PSStyle.explain}>
                             <div className={PSStyle.name}>{popupstore.name}</div>

--- a/frontend/src/componenets/user/usersearch/SearchBar.jsx
+++ b/frontend/src/componenets/user/usersearch/SearchBar.jsx
@@ -123,7 +123,7 @@ function SearchBar(){
         </select>
 
         <div className={TPStyle.popuplayout}>
-            {popups.length==0? <NoSearchResult props={searchWord} /> : popups.map(popup=> <PopupStores key={popup.no} popupstore={popup} setIsDrag={setIsDrag} posterNo={popup.no}/>)}
+            {popups.length==0? <NoSearchResult props={searchWord} /> : popups.map(popup=> <PopupStores key={popup.no} popupstore={popup} setIsDrag={setIsDrag} posterNo={popup.no} />)}
         </div>
         </>
     )


### PR DESCRIPTION
## ✔ 관련 이슈 번호 
#89 
## 📃 작업 상세 내용 
오늘 날짜 기준 앞으로 10일동안 해당 날짜에 진행중인 팝업 랜덤 10개 조회
선택한 날짜만 css 변경
하단 더보기 버튼 클릭 시 선택한 요일에 진행중인 팝업을 전부 보여주는 기능 추가?
(팝플리는 날짜 선택하고 더보기 눌러도 오늘 날짜로 조회됨...)
## 📸 결과 
디폴트
<img width="1920" height="918" alt="image" src="https://github.com/user-attachments/assets/a4dab204-040e-4879-b02f-fca0c93e9e9b" />
선택
<img width="1920" height="920" alt="image" src="https://github.com/user-attachments/assets/3d2661c9-547d-4627-a7d5-1dab6033e075" />
코드
<img width="1338" height="363" alt="image" src="https://github.com/user-attachments/assets/beee9987-5730-43d7-b748-6a8ca29718c0" />

