### PR TITLE
[FIX] manager 사이드바 메뉴 변경

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import MyPopupPage from "./pages/manager/mypopup";
 import MypopupdetPage from "./pages/manager/mypopupdet";
 import PopupRegister from "./pages/manager/popup-register";
 import ReservationPage from "./pages/manager/reservations";
+import MyPopupLayout from "./pages/manager/MyPopupLayout";
 import MyInformation from "./pages/user/MyInfo"
 import MyReview from "./pages/user/MyReviews"
 import MyReservation from "./pages/user/MyReservations"
@@ -105,9 +106,15 @@ function App() {
             <Route element={<ProtectedRoute requiredRoles={['MANAGER']} />}>
               <Route path="/manager/dashboard" element={<Dashboard />} />
               <Route path="/manager/mypopup" element={<MyPopupPage />} />
-              <Route path="/manager/mypopupdet" element={<MypopupdetPage />} />
+              {/* 선택된 팝업 전용 레이아웃 */}
+              <Route path="/manager/mypopup/:popupNo" element={<MyPopupLayout />}>
+                <Route index element={<Dashboard />} />                {/* 기본 탭 */}
+                <Route path="detail" element={<MypopupdetPage />} />   {/* 상세 */}
+                <Route path="reservations" element={<ReservationPage />} /> {/* 예약 */}
+              </Route>
+              {/* <Route path="/manager/mypopupdet" element={<MypopupdetPage />} /> */}
               <Route path="/manager/popup-register" element={<PopupRegister />} />
-              <Route path="/manager/reservations" element={<ReservationPage />} />
+              {/* <Route path="/manager/reservations" element={<ReservationPage />} /> */}
             </Route>
 
             {/* 관리자 보호 라우트 */}

--- a/frontend/src/componenets/manager/mypopup/mypopup.css
+++ b/frontend/src/componenets/manager/mypopup/mypopup.css
@@ -113,3 +113,63 @@
   margin-top:12px; 
   font-weight:700;
 }
+
+/* ====== 팝업 상세  ====== */
+.mp-popup-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--text, #1a1a1a);
+}
+
+.mp-popup-label {
+  font-weight: 600;
+  color: #555;
+}
+
+.mp-popup-value {
+  font-weight: 700;
+  color: #000;
+}
+
+
+.btn-detail {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+
+  color: #3a63f3;            
+  background: #ffffff;
+  border: 1px solid #d4dcf8;
+  border-radius: 999px;
+
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.03);
+  cursor: pointer;
+  transition: background-color 0.15s ease, box-shadow 0.15s ease, transform 0.1s ease;
+
+}
+
+.btn-detail:hover {
+  background: #f3f6ff;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.05);
+}
+
+.btn-detail:active {
+  transform: translateY(1px);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+}
+
+
+.btn-detail:hover {
+  background: #e5e8ef;
+}
+
+.btn-detail:active {
+  background: #d9dde6;
+}
+

--- a/frontend/src/componenets/manager/mypopup/mypopup.jsx
+++ b/frontend/src/componenets/manager/mypopup/mypopup.jsx
@@ -1,5 +1,6 @@
 import "./mypopup.css";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";  
 import ManagerSearchBar from "../ManagerSearchBar";
 
 const MOCK = [
@@ -12,6 +13,7 @@ const MOCK = [
 function MyPopup() {
   const [q, setQ] = useState("");
   const [sortKey, setSortKey] = useState("latest");
+  const navigate = useNavigate();  
 
   let filtered = MOCK.filter(r =>
     [r.title, r.state, r.location, r.category]
@@ -22,6 +24,14 @@ function MyPopup() {
 
   if (sortKey === "title") filtered.sort((a, b) => a.title.localeCompare(b.title));
   if (sortKey === "state") filtered.sort((a, b) => a.state.localeCompare(b.state));
+
+  const goDashboard = (id) => {
+    navigate(`/manager/mypopup/${id}`);
+  };
+
+  const goDetail = (id) => {
+    navigate(`/manager/mypopup/${id}/detail`);
+  };
 
   return (
     <div className="mp-wrap">
@@ -54,7 +64,7 @@ function MyPopup() {
             <div>날짜</div>
             <div>위치</div>
             <div>카테고리</div>
-            <div className="center">편집</div>
+            <div className="center">관리</div>
           </div>
 
           {filtered.map(row => (
@@ -64,8 +74,13 @@ function MyPopup() {
               <div>{row.date}</div>
               <div>{row.location}</div>
               <div>{row.category}</div>
-              <div className="center">
-                <button className="btn-edit" onClick={() => alert(`편집: ${row.title}`)}>편집</button>
+              <div className="center mp-actions">
+                <button
+                  className="btn-detail"
+                  onClick={() => goDetail(row.id)}
+                >
+                  상세
+                </button>
               </div>
             </div>
           ))}

--- a/frontend/src/componenets/manager/mypopup/mypopupdet.css
+++ b/frontend/src/componenets/manager/mypopup/mypopupdet.css
@@ -2,7 +2,7 @@
 .mypopupdet-wrapper {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 12px;
   width: 100%;
   background-color: #f5f6f8;
   min-height: 100vh;
@@ -11,27 +11,20 @@
   font-family: "Pretendard", sans-serif;
 }
 
+.mypopupdet-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;     
+}
+
+.mypopupdet-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #333;
+}
+
 /* ====== 헤더 ====== */
-
-.mypopupdet-search-input {
-  padding: 8px 12px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  width: 200px;
-  font-size: 14px;
-}
-
-.mypopupdet-search-btn {
-  background-color: #333;
-  color: #fff;
-  border: none;
-  padding: 8px 16px;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 14px;
-  transition: background-color 0.2s;
-}
-
 .mypopupdet-search-btn:hover {
   background-color: #555;
 }
@@ -138,19 +131,63 @@
 /* 검색바 — 제목 바로 아래 */
 .mypopupdet-search-area {
   width: 100%;
-  margin-bottom: 3px;
+  margin-bottom: 2px;
 }
 
-/* 전체 예약자 수 — 검색바 아래, 오른쪽 */
 .mypopupdet-total-wrap {
   width: 100%;
   text-align: right;
   margin-bottom: 5px;
-  font-size: 20px;
+  font-size: 16px;
   color: #555;
 }
 
-.mypopupdet-total-wrap strong {
-  color: #000;
-  font-weight: 700;
+/* 상단: manager + 탭 줄 */
+.mypopupdet-toprow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
 }
+
+.mypopupdet-top-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #555;
+}
+
+.mypopupdet-selected strong {
+  font-weight: 700;
+  color: #000;
+}
+
+/* 탭 영역 */
+.mypopupdet-tabs {
+  display: flex;
+  gap: 12px;             
+  margin-bottom: 16px;
+}
+
+.mypopupdet-tab-item {
+  padding: 8px 18px;
+  font-size: 15px;
+  font-weight: 500;
+  border-radius: 999px;
+  text-decoration: none;
+  color: #666;
+  background-color: #f5f6f8;
+  transition: 0.15s ease-in-out;
+}
+
+.mypopupdet-tab-item:hover {
+  background-color: #e9edf5;
+}
+
+.mypopupdet-tab-item.active {
+  background-color: #111;
+  color: #fff;
+  font-weight: 700; 
+}
+

--- a/frontend/src/componenets/manager/mypopup/mypopupdet.jsx
+++ b/frontend/src/componenets/manager/mypopup/mypopupdet.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import "./mypopupdet.css";
 import ManagerSearchBar from "../ManagerSearchBar";
+import { NavLink, useParams } from "react-router-dom";
 
 function MyPopupDet() {
 
@@ -10,6 +11,8 @@ function MyPopupDet() {
   const [reservations, setReservations] = useState([]);
 
   const [keyword, setKeyword] = useState("");
+
+  const { popupNo } = useParams();
 
   useEffect(() => {
 
@@ -38,7 +41,50 @@ function MyPopupDet() {
     <div className="mypopupdet-wrapper">
     
       <div className="mypopupdet-header">
-    
+
+      <div className="mypopupdet-total-wrap">
+        전체 예약자 수 <strong>{popupInfo ? popupInfo.totalCount : 0}명</strong>
+      </div>
+      </div>
+
+      <div className="mypopupdet-toprow">
+        <div className="mypopupdet-top-left">
+          <span className="badge">manager01</span>
+          <span className="mypopupdet-selected">
+            선택된 팝업 <strong>#{popupNo}</strong>
+          </span>
+        </div>
+
+        <div className="mypopupdet-tabs">
+          <NavLink
+            to={`/manager/mypopup/${popupNo}/detail`}
+            className={({ isActive }) =>
+              "mypopupdet-tab-item" + (isActive ? " active" : "")
+            }
+          >
+            상세보기
+          </NavLink>
+          <NavLink
+            end
+            to={`/manager/mypopup/${popupNo}`}
+            className={({ isActive }) =>
+              "mypopupdet-tab-item" + (isActive ? " active" : "")
+            }
+          >
+            대시보드
+          </NavLink>
+
+          <NavLink
+            to={`/manager/mypopup/${popupNo}/reservations`}
+            className={({ isActive }) =>
+              "mypopupdet-tab-item" + (isActive ? " active" : "")
+            }
+          >
+            예약 내역
+          </NavLink>
+        </div>
+      </div>
+
       <div className="mypopupdet-search-area">
         <ManagerSearchBar
           value={keyword}
@@ -46,12 +92,6 @@ function MyPopupDet() {
           placeholder="예약 내역 검색"
         />
       </div>
-
-      <div className="mypopupdet-total-wrap">
-        전체 예약자 수 <strong>{popupInfo ? popupInfo.totalCount : 0}명</strong>
-      </div>
-      </div>
-
     
       {popupInfo && (
         <section className="mypopupdet-info-card">

--- a/frontend/src/layouts/managermain/manager-sidebar.jsx
+++ b/frontend/src/layouts/managermain/manager-sidebar.jsx
@@ -60,60 +60,16 @@ function ManagerSidebar() {
           팝업스토어 등록
         </NavLink>
 
-        <div
-          className={
-            "admin-side-button" + (isMyPopupOpen ? " active" : "")
+        <NavLink
+          to="/manager/mypopup"  // 나의 팝업스토어 메인 페이지
+          className={({ isActive }) =>
+            "admin-side-button" + (isActive ? " active" : "")
           }
-          onClick={() => setIsMyPopupOpen((prev) => !prev)}
         >
           <img src="/icons/shop.png" alt="shop" className="side-icon" />
           나의 팝업스토어
-          <span
-            className="arrow-icon"
-            style={{
-              transform: isMyPopupOpen ? "rotate(90deg)" : "rotate(0deg)",
-            }}
-          >
-            &gt;
-          </span>
-        </div>
+        </NavLink>
 
-        {isMyPopupOpen && (
-          <div className="admin-submenu-layout">
-            <NavLink
-              to="/manager/dashboard"
-              className={({ isActive }) =>
-                "admin-submenu-item" + (isActive ? " active" : "")
-              }
-            >
-              대시보드
-            </NavLink>
-            <NavLink
-                to="/manager/reservations"
-                className={({ isActive }) =>
-                "admin-submenu-item" + (isActive ? " active" : "")
-                }
-            >
-                예약 내역
-            </NavLink>
-            <NavLink
-              to="/manager/mypopup"
-              className={({ isActive }) =>
-                "admin-submenu-item" + (isActive ? " active" : "")
-              }
-            >
-              내 팝업 스토어
-            </NavLink>
-              <NavLink
-                to="/manager/mypopupdet"
-                className={({ isActive }) =>
-                "admin-submenu-item" + (isActive ? " active" : "")
-                }
-            >
-            내 팝업스토어 상세보기
-            </NavLink>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/manager/MyPopupLayout.jsx
+++ b/frontend/src/pages/manager/MyPopupLayout.jsx
@@ -1,0 +1,8 @@
+import { Outlet } from "react-router-dom";
+
+function MyPopupLayout() {
+  // 라우팅만 담당, 실제 UI는 각 페이지에서
+  return <Outlet />;
+}
+
+export default MyPopupLayout;


### PR DESCRIPTION
## ✔ 관련 이슈 번호 
#97 

## 📃 작업 상세 내용 
manager 사이드바 메뉴 수정
기존 <br> 
나의 팝업 스토어-> 대시보드, 상세보기, 예약내역 <br>
수정 <br> 
나의 팝업 스토어 [상세버튼] 추가-> 나의 팝업스토어 페이지에서 버튼으로 대시보드, 상세보기, 예약내역 선택

## 📸 결과 
상세버튼 추가
<img width="1000" height="600" alt="스크린샷 2025-11-19 오후 3 27 03" src="https://github.com/user-attachments/assets/7047f116-9c1a-4440-a288-bdc5eff3ffdc" />

대시보드 | 상세보기| 예약내역 버튼 추가
<img width="1000" height="600" alt="스크린샷 2025-11-19 오후 3 27 48" src="https://github.com/user-attachments/assets/212727ab-9171-46ad-9122-6b42c027c641" />
