### PR TITLE
[FEATURE] admin 대시보드 꺾은 선 차트 구현

### DIFF
--- a/backend/src/main/java/com/ohgiraffers/poppop/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/ohgiraffers/poppop/admin/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.ohgiraffers.poppop.admin.controller;
 
 
+import com.ohgiraffers.poppop.admin.model.dto.MonthlyMemberActivityDTO;
 import com.ohgiraffers.poppop.admin.model.dto.MonthlyVisitorStatsDTO;
 import com.ohgiraffers.poppop.admin.model.dto.UserKpiDTO;
 import com.ohgiraffers.poppop.admin.model.dto.YearlyVisitorStatsDTO;
@@ -160,5 +161,11 @@ public class AdminController {
     @GetMapping("/kpi/yearly-visitor-stats")
     public ResponseEntity<List<YearlyVisitorStatsDTO>> selectYearlyVisitorStats() {
         return ResponseEntity.ok(kpiService.selectYearlyVisitorStats());
+    }
+
+    // User 대시보드 꺾은 선 차트 활동회원 비율 조회
+    @GetMapping("/kpi/monthly-member-activity")
+    public ResponseEntity<List<MonthlyMemberActivityDTO>> selectMontlyMemberActivityStats() {
+        return ResponseEntity.ok(kpiService.selectMonthlyMemberActivityStats());
     }
 }

--- a/backend/src/main/java/com/ohgiraffers/poppop/admin/model/dao/KpiMapper.java
+++ b/backend/src/main/java/com/ohgiraffers/poppop/admin/model/dao/KpiMapper.java
@@ -1,5 +1,6 @@
 package com.ohgiraffers.poppop.admin.model.dao;
 
+import com.ohgiraffers.poppop.admin.model.dto.MonthlyMemberActivityDTO;
 import com.ohgiraffers.poppop.admin.model.dto.MonthlyVisitorStatsDTO;
 import com.ohgiraffers.poppop.admin.model.dto.YearlyVisitorStatsDTO;
 import org.apache.ibatis.annotations.Mapper;
@@ -17,4 +18,6 @@ public interface KpiMapper {
 
     List<MonthlyVisitorStatsDTO> selectMonthlyVisitorStats();
     List<YearlyVisitorStatsDTO> selectYearlyVisitorStats();
+    List<MonthlyMemberActivityDTO> selectMonthlyActiveMembers();
+    List<MonthlyMemberActivityDTO> selectMonthlyTotalMembersCumulative();
 }

--- a/backend/src/main/java/com/ohgiraffers/poppop/admin/model/dto/MonthlyMemberActivityDTO.java
+++ b/backend/src/main/java/com/ohgiraffers/poppop/admin/model/dto/MonthlyMemberActivityDTO.java
@@ -1,0 +1,60 @@
+package com.ohgiraffers.poppop.admin.model.dto;
+
+public class MonthlyMemberActivityDTO {
+
+    private int visitYear;
+    private int visitMonth;
+    private long activeMembers;
+    private long totalMembersAtEndOfMonth;
+
+    public MonthlyMemberActivityDTO() {}
+
+    public MonthlyMemberActivityDTO(int visitYear, int visitMonth, long activeMembers, long totalMembersAtEndOfMonth) {
+        this.visitYear = visitYear;
+        this.visitMonth = visitMonth;
+        this.activeMembers = activeMembers;
+        this.totalMembersAtEndOfMonth = totalMembersAtEndOfMonth;
+    }
+
+    public int getVisitYear() {
+        return visitYear;
+    }
+
+    public void setVisitYear(int visitYear) {
+        this.visitYear = visitYear;
+    }
+
+    public int getVisitMonth() {
+        return visitMonth;
+    }
+
+    public void setVisitMonth(int visitMonth) {
+        this.visitMonth = visitMonth;
+    }
+
+    public long getActiveMembers() {
+        return activeMembers;
+    }
+
+    public void setActiveMembers(long activeMembers) {
+        this.activeMembers = activeMembers;
+    }
+
+    public long getTotalMembersAtEndOfMonth() {
+        return totalMembersAtEndOfMonth;
+    }
+
+    public void setTotalMembersAtEndOfMonth(long totalMembersAtEndOfMonth) {
+        this.totalMembersAtEndOfMonth = totalMembersAtEndOfMonth;
+    }
+
+    @Override
+    public String toString() {
+        return "MonthlyMemberActivityDTO{" +
+                "visitYear=" + visitYear +
+                ", visitMonth=" + visitMonth +
+                ", activeMembers=" + activeMembers +
+                ", totalMembersAtEndOfMonth=" + totalMembersAtEndOfMonth +
+                '}';
+    }
+}

--- a/backend/src/main/java/com/ohgiraffers/poppop/admin/model/service/KpiService.java
+++ b/backend/src/main/java/com/ohgiraffers/poppop/admin/model/service/KpiService.java
@@ -1,12 +1,16 @@
 package com.ohgiraffers.poppop.admin.model.service;
 
 import com.ohgiraffers.poppop.admin.model.dao.KpiMapper;
+import com.ohgiraffers.poppop.admin.model.dto.MonthlyMemberActivityDTO;
 import com.ohgiraffers.poppop.admin.model.dto.MonthlyVisitorStatsDTO;
 import com.ohgiraffers.poppop.admin.model.dto.UserKpiDTO;
 import com.ohgiraffers.poppop.admin.model.dto.YearlyVisitorStatsDTO;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 public class KpiService {
@@ -33,5 +37,53 @@ public class KpiService {
 
     public List<YearlyVisitorStatsDTO> selectYearlyVisitorStats() {
         return kpiMapper.selectYearlyVisitorStats();
+    }
+
+    public List<MonthlyMemberActivityDTO> selectMonthlyMemberActivityStats() {
+
+        // 월별 활동 회원 수
+        List<MonthlyMemberActivityDTO> activeMembersList = kpiMapper.selectMonthlyActiveMembers();
+
+        // 월별 누적 총 회원 수
+        List<MonthlyMemberActivityDTO> totalMembersList = kpiMapper.selectMonthlyTotalMembersCumulative();
+
+        // 월별 활동 회원 수, 누적 총 회원 수를 연도-월 을 키로 하는 맵으로 변환하여 병합
+        // activeMembersList를 기준으로 맵 생성
+        Map<String, MonthlyMemberActivityDTO> combinedMap = activeMembersList.stream()
+                .collect(Collectors.toMap(
+                        dto -> dto.getVisitYear() + "-" + dto.getVisitMonth(),
+                        Function.identity()
+                ));
+
+        // totalMembersList를 순회하며 맵에 누적 회원 수를 업데이트
+        totalMembersList.forEach(totalDto -> {
+            String key = totalDto.getVisitYear() + "-" + totalDto.getVisitMonth();
+            // 맵에 해당 월이 이미 있으면(활동 회원) 누적 회원 수를 설정
+            // 없으면 새로운 엔트리 추가
+            combinedMap.compute(key, (k, existingDto) -> {
+                if (existingDto != null) {
+                    existingDto.setTotalMembersAtEndOfMonth(totalDto.getTotalMembersAtEndOfMonth());
+                    return existingDto;
+                } else {
+                    return new MonthlyMemberActivityDTO(
+                            totalDto.getVisitYear(),
+                            totalDto.getVisitMonth(),
+                            0,
+                            totalDto.getTotalMembersAtEndOfMonth()
+                    );
+                }
+            });
+        });
+
+        // 맵의 값들을 리스트로 변환하고, 연도와 월 순으로 정렬하여 반환
+        return combinedMap.values().stream()
+                .sorted((d1, d2) -> {
+                    int yearCompare = Integer.compare(d1.getVisitYear(), d2.getVisitYear());
+                    if (yearCompare != 0) {
+                        return yearCompare;
+                    }
+                    return Integer.compare(d1.getVisitMonth(), d2.getVisitMonth());
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/resources/mappers/KpiMapper.xml
+++ b/backend/src/main/resources/mappers/KpiMapper.xml
@@ -39,6 +39,52 @@
          order by visit_year asc
     </select>
 
+<!--    MonthlyMemberActivityStats ResultMap-->
+<resultMap id="monthlyMemberActivityStatsResultMap" type="com.ohgiraffers.poppop.admin.model.dto.MonthlyMemberActivityDTO">
+    <result property="visitYear" column="visit_year"/>
+    <result property="visitMonth" column="visit_month"/>
+    <result property="activeMembers" column="active_members"/>
+    <result property="totalMembersAtEndOfMonth" column="total_members_at_end_of_month"/>
+</resultMap>
+<!--    월별 활동 회원 수-->
+    <select id="selectMonthlyActiveMembers" resultMap="monthlyMemberActivityStatsResultMap">
+        select
+               year(e.time_stamp) as visit_year,
+               month(e.time_stamp) as visit_month,
+               count(distinct s.id) as active_members
+          from session_info s
+          join user_event_data e on s.session_id = e.session_id
+         where s.id is not null
+         group by year(e.time_stamp), month(e.time_stamp)
+         order by visit_year asc, visit_month asc
+    </select>
+<!--    월별 누적 총 회원 수(해당 월 말 기준)-->
+    <select id="selectMonthlyTotalMembersCumulative" resultMap="monthlyMemberActivityStatsResultMap">
+        <![CDATA[
+        with recursive monthseries as (
+            select
+                   date_format(min(signup_date), '%Y-%m-01') as month_start,
+                   last_day(min(signup_date)) as month_end
+              from member
+             union all
+            select
+                   date_add(month_start, interval 1 month),
+                   last_day(date_add(month_start, interval 1 month))
+              from monthseries
+             where month_start < date_format(curdate(), '%Y-%m-01')
+        )
+        select
+               year(ms.month_start) as visit_year,
+               month(ms.month_start) as visit_month,
+               0 as active_members,
+               count(m.id) as total_members_at_end_of_month
+          from monthseries ms
+          left join member m on m.signup_date <= ms.month_end
+         group by year(ms.month_start), month(ms.month_start)
+         order by visit_year asc, visit_month asc
+        ]]>
+    </select>
+
 <!--    전체 회원 수-->
     <select id="selectTotalMembers" resultType="long">
         select count(*) from member

--- a/frontend/src/api/adminAPI.jsx
+++ b/frontend/src/api/adminAPI.jsx
@@ -124,3 +124,23 @@ export function selectUserKpiData() {
         throw error;
     });
 }
+
+// user 대시보드 꺾은 선 차트 월별 회원가입률 조회
+export function selectMonthlyVisitorStats() {
+    return API.get(`${BACKEND_URL}/admin/kpi/monthly-visitor-stats`)
+    .then(response=>response.data)
+    .catch(error=> {
+        console.error("API call error in selectMonthlyVisitorStats");
+        throw error;
+    });
+}
+
+// user 대시보드 꺾은 선 차트 월별 활동회원 비율 조회
+export function selectMonthlyMemberActivityStats() {
+    return API.get(`${BACKEND_URL}/admin/kpi/monthly-member-activity`)
+    .then(response=>response.data)
+    .catch(error=> {
+        console.error("API call error in selectMonthlyMemberActivityStats", error);
+        throw error;
+    });
+}

--- a/frontend/src/componenets/admin/adminLineChart.jsx
+++ b/frontend/src/componenets/admin/adminLineChart.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Line } from 'react-chartjs-2';
 import {
     Chart as ChartJS,
@@ -8,39 +8,136 @@ import {
     LineElement,
     Tooltip,
     Legend,
+    Interaction,
 } from 'chart.js';
+import { selectMonthlyVisitorStats, selectMonthlyMemberActivityStats } from "../../api/adminAPI";
+import { callback } from "chart.js/helpers";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
-function AdminLineChart({ data, options, height, width }) {
-    const defaultData = {
-        labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
-        datasets: [
-            {
-                label: "Users",
-                data: [120, 200, 150, 220, 180, 240],
-                borderColor: "FFCF0D",
-                backgroundColor: "rgba(255, 207, 13, 0.12)",
-                tension: 0.3,
-                fill: true,
-                pointRadius: 3,
+function AdminLineChart({ options, height, width }) {
+    const [chartData, setChartData] = useState({
+        labels: [],
+        datasets: []
+    });
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        const fetchChartData = async () => {
+            try {
+                setLoading(true);
+
+                // 월별 데이터 로드 (Promise.all로 2개의 API를 동시 요청)
+                const [
+                    visitorStats,   // 회원가입률
+                    memberActivityStats // 활동 회원 비율
+                ] = await Promise.all([
+                    selectMonthlyVisitorStats(),
+                    selectMonthlyMemberActivityStats()
+                ]);
+
+                if (visitorStats && visitorStats.length > 0) {
+
+                    const labels = visitorStats.map(item => `${item.visitMonth}월`);
+
+                    // 월별 회원가입률 계산 (회원 가입 수 / 방문자 수 * 100)
+                    const signupRates = visitorStats.map(item => {
+                        // 방문자 수가 0일 경우 0으로 처리하여 NaN 방지
+                        if (item.visitorCount === 0) return 0;
+                        return ((item.signupCount / item.visitorCount ) * 100).toFixed(2);
+                    });
+
+                    // 월별 활동 회원 비율 계산 (활동 회원 수 / 회원 수 * 100)
+                    const activeMemberRates = memberActivityStats.map(item => {
+                        if (item.totalMembersAtEndOfMonth === 0) return 0;
+                        return ((item.activeMembers / item.totalMembersAtEndOfMonth) * 100).toFixed(2);
+                    });
+
+                    setChartData({
+                        labels: labels,
+                        datasets: [
+                            {
+                                label: "월별 회원가입률 (%)",
+                                data: signupRates,
+                                borderColor: 'rgb(255, 99, 132)',
+                                backgroundColor: 'rgba(255, 99, 132, 0.5)'
+                            },
+                            {
+                                label: "활동 회원 비율 (%)",
+                                data: activeMemberRates,
+                                borderColor: 'rgb(54, 162, 235)',
+                                backgroundColor: 'rgba(54, 162, 235, 0.5)'
+                            }
+                        ]
+                    });
+                } else {
+                    setChartData({
+                        labels: ["데이터 없음."],
+                        datasets: [{ label: "데이터 없음.", data: [0] }]
+                    });
+                }
+            } catch (err) {
+                setError("데이터를 불러오는 데 실패했습니다.");
+                console.error("Error fetching monthly visitor stats:", err);
+                setChartData({
+                    labels: ["오류"],
+                    datasets: [{ label: "오류", data: [0] }]
+                });
+            } finally {
+                setLoading(false);
             }
-        ]
-    };
+        };
+
+        fetchChartData();
+    }, []);
 
     const chartOptions = options || {
         responsive: true,
         maintainAspectRatio: false,
-        plugins: { legend: { position: 'top' }, tooltip: { enabled: true } },
+        Interaction: { mode: 'index', intersect: false },
+        plugins: { 
+            legend: { position: 'top' }, 
+            tooltip: { 
+                mode: 'index',
+                intersect: false,
+                callbacks: {
+                    label: function(context) {
+                        let label = context.dataset.label || '';
+                        if (label) {
+                            label += ': ';
+                        }
+                        if (context.parsed.y !== null) {
+                            label += context.parsed.y + '%';
+                        }
+                        return label;
+                    }
+                }
+             }
+        },
         scales: {
-            x: { grid: { display: false } },
-            y: { grid: { color: "rgba(255,255,255,0.03)" }, beginAtZero: true }
+            y: {
+                title: { display: true, text: '비율 (%)' },
+                ticks: {
+                    callback: function(value) {
+                        return value + '%';
+                    }
+                }
+            }
         }
     };
 
+    if (loading) {
+        return <div>로딩 중...</div>
+    }
+
+    if (error) {
+        return <div>오류: {error}</div>
+    }
+
     return (
         <div style={{ height: height, width: width }}>
-            <Line data={data || defaultData} options={chartOptions} />
+            <Line data={chartData} options={chartOptions} />
         </div>
     );
 }


### PR DESCRIPTION
## ✔ 관련 이슈 번호 
#99 
## 📃 작업 상세 내용 
back 꺾은 선 차트에 표시할 데이터 DTO 생성 및 매퍼 매핑
back 매퍼 인터페이스, 서비스, 컨트롤러 해당 데이터 메소드 추가
front AdminAPI 데이터 요청 함수 추가
front AdminLineChart 응답 데이터 표시
## 📸 결과 
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/43bea71e-cae5-426f-86f6-d4d1a084a7e3" />

