### PR TITLE
[FIX] admin 대시보드 꺾은 선 차트 수정

### DIFF
--- a/frontend/src/componenets/admin/adminLineChart.jsx
+++ b/frontend/src/componenets/admin/adminLineChart.jsx
@@ -13,7 +13,7 @@ import { selectDailyVisitorStats } from "../../api/adminAPI";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
-function AdminLineChart({ options, height, width }) {
+function AdminLineChart({ options }) {
     const [chartData, setChartData] = useState({
         labels: [],
         datasets: []
@@ -97,6 +97,47 @@ function AdminLineChart({ options, height, width }) {
         }
     };
 
+    // 차트의 Y축 항목을 5개로 동적으로 계산하는 함수
+    const generateYItem = () => {
+        // 데이터가 없으면 기본 설정 반환
+        if (!chartData.datasets || chartData.datasets.length === 0 || chartData.datasets.every(d => d.data.length === 0)) {
+            return {
+                beginAtZero: true,
+                title: { display: true, text: '방문자 수 (명) '},
+                max: 40,
+                ticks: {
+                    stepSize: 10,
+                    autoSkip: false
+                }
+            };
+        }
+
+        // 모든 데이터셋의 데이터를 하나의 배열로 합친 후 최대값 찾기
+        const allData = chartData.datasets.flatMap(dataset => dataset.data);
+        const dataMax = Math.max(...allData, 0);
+
+        // dataMax보다 크거나 같은 4의 배수 중 가장 작은 값을 newMax로 설정
+        let newMax = Math.ceil(dataMax / 4) * 4;
+
+        // 계산된 newMax가 0이면 최소값을 설정하여 0으로 나누는 것 방지
+        if (newMax === 0) {
+            newMax = 4;
+        }
+
+        // 5개의 눈금(0 포함)을 만들기 위해 stepSize를 newMax/4로 계산
+        const stepSize = newMax / 4;
+
+        return {
+            beginAtZero: true,
+            title: { display: true, text: '방문자 수 (명)' },
+            max: newMax,
+            ticks: {
+                stepSize: stepSize,
+                autoSkip: false
+            }
+        };
+    };
+
     // X축 툴팁 콜백 함수 및 동적 제목 적용
     const chartOptions = options || {
         responsive: true,
@@ -146,10 +187,7 @@ function AdminLineChart({ options, height, width }) {
                     text: generateXTitle()
                 }
             },
-            y: {
-                beginAtZero: true,
-                title: { display: true, text: '방문자 수 (명)' },
-            }
+            y: generateYItem()
         }
     };
 
@@ -162,7 +200,7 @@ function AdminLineChart({ options, height, width }) {
     }
 
     return (
-        <div style={{ height: height, width: width }}>
+        <div style={{ position: 'relative', height: '100%', width: '90%' }}>
             <Line data={chartData} options={chartOptions} />
         </div>
     );

--- a/frontend/src/layouts/adminmain/admin-main.css
+++ b/frontend/src/layouts/adminmain/admin-main.css
@@ -103,33 +103,45 @@
     background-color: #ffffff;
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
-    justify-content: flex-start;
     box-sizing: border-box;
     box-shadow: 5px 5px 8px rgba(0, 0, 0, 0.1);
+    padding-bottom: 15px;
 }
 
 .chart-header{
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     justify-content: space-between;
     width: 100%;
+    height: 40px;
 }
 
 .chart-title{
     font-family: 'pretendard', sans-serif;
     font-size: 20px;
     font-weight: 600;
-    margin-bottom: 10px;
     padding-left: 20px;
 }
 
 .chart-button{
     width: 100px;
-    height: 35px;
+    height: 30px;
     border-radius: 5px;
-    margin-top: 15px;
+    margin-top: 5px;
     margin-right: 30px;
+    background: linear-gradient(to right, #eba9cf, #f4002d);
+    color: white;
+    border: none;
+    cursor: pointer;
+}
+
+.admin-LineChart{
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding-top: 10px;
+    flex-grow: 1;
 }
 
 .admin-chart{

--- a/frontend/src/layouts/adminmain/admin-main.jsx
+++ b/frontend/src/layouts/adminmain/admin-main.jsx
@@ -1,6 +1,6 @@
 import "./Admin-main.css"
-import AdminChart from "../../componenets/admin/adminChart"
-import AdminLineChart from "../../componenets/admin/adminLineChart"
+import AdminChart from "../../componenets/admin/AdminChart"
+import AdminLineChart from "../../componenets/admin/AdminLineChart"
 import AdminBarChart from "../../componenets/admin/adminBarChart"
 import KPIData from "../../componenets/admin/adminKPIData"
 
@@ -13,15 +13,15 @@ function AdminMain (){
             <div className="admin-chart-layout">
                 <div className="admin-chart-box">
                     <div className="chart-header">
-                        <p className="chart-title">차트 1 입니다.</p>
-                        <button className="chart-button">기간</button>
+                        <p className="chart-title">플랫폼 성장 추이</p>
+                        <button className="chart-button">기간설정</button>
                     </div>
-                    <div className="admin-chart"><AdminChart height={200} width={400}/></div>
+                    <div className="admin-LineChart"><AdminLineChart/></div>
                 </div>
                 <div className="admin-chart-box">
                     <div className="chart-header">
-                        <p className="chart-title">차트 2 입니다.</p>
-                        <button className="chart-button">기간</button>
+                        <p className="chart-title">유입 경로</p>
+                        <button className="chart-button">기간설정</button>
                     </div>
                     <div className="admin-chart"><AdminChart height={200} width={400}/></div>
                 </div>
@@ -30,14 +30,14 @@ function AdminMain (){
                 <div className="admin-chart-box">
                     <div className="chart-header">
                         <p className="chart-title">차트 3 입니다.</p>
-                        <button className="chart-button">기간</button>
+                        <button className="chart-button">기간설정</button>
                     </div>
-                    <div className="admin-chart"><AdminLineChart height={200} width={360}/></div>
+                    <div className="admin-chart"><AdminLineChart/></div>
                 </div>
                 <div className="admin-chart-box">
                     <div className="chart-header">
                         <p className="chart-title">차트 4 입니다.</p>
-                        <button className="chart-button">기간</button>
+                        <button className="chart-button">기간설정</button>
                     </div>
                     <div className="admin-chart"><AdminBarChart height={200} width={360}/></div>
                 </div>


### PR DESCRIPTION
## ✔ 관련 이슈 번호 
#119 
## 📃 작업 상세 내용 
y축 항목 5개로 고정 표시 데이터 크기에 따라 동적으로 항목 값 설정
차트 크기 조절

## 📸 결과 
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/4e17f0d3-5a44-4097-98bd-10ff3bee0174" />
