### PR TITLE
[FIX] user 페이지 팝업스토어 관련 url 수정

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -74,7 +74,7 @@ function App() {
         
             <Route index element={<RedirectBasedOnRole />} />
 
-            <Route path="/user">
+            <Route path="/popup-stores">
               <Route index element={<User />} />
 
               <Route path=":popupNo" element={<PopupDetails />} />

--- a/frontend/src/componenets/PopupStores.jsx
+++ b/frontend/src/componenets/PopupStores.jsx
@@ -44,7 +44,7 @@ function PopupStores({popupstore,setIsDrag,posterNo}){
     return(
         <>
             
-                <Link to={`/user/${popupstore.no}`}>
+                <Link to={`/popup-stores/${popupstore.no}`}>
                     <div ref={preview}></div>
                     <div className={PSStyle.layout} ref={drag}>
                         <div className={PSStyle.image}>

--- a/frontend/src/componenets/maps/Map.jsx
+++ b/frontend/src/componenets/maps/Map.jsx
@@ -63,7 +63,7 @@ function KakaoMap({ popupStores=[] }){
                     }}
                     title={store.name}
                     onClick={() => {
-                        navigate(`/user/${store.popupNo}`);
+                        navigate(`/popup-stores/${store.popupNo}`);
                     }}
                 />
             ))}                

--- a/frontend/src/componenets/user/usermain/PopupComp.jsx
+++ b/frontend/src/componenets/user/usermain/PopupComp.jsx
@@ -46,7 +46,7 @@ function PopupComp({popupstore,posterNo}){
     return(
         <>
             
-                <Link to={`/user/${popupstore.no}`} onClick={()=>{onClickLog;location.href(`/user/${popupstore.no}`)}}>
+                <Link to={`/popup-stores/${popupstore.no}`} onClick={()=>{onClickLog;location.href(`/popup-stores/${popupstore.no}`)}}>
                 <div className={PSStyle.back}>
                     <img src={posterUrl} alt={posterNo} />
 

--- a/frontend/src/componenets/user/userreview/UserReview.jsx
+++ b/frontend/src/componenets/user/userreview/UserReview.jsx
@@ -18,6 +18,7 @@ function UserReview(){
     const onClickRegist=()=>{
         insertReview(content,popupNo)
         
+        
     }
 
 

--- a/frontend/src/layouts/userdetail/Popups.jsx
+++ b/frontend/src/layouts/userdetail/Popups.jsx
@@ -64,10 +64,10 @@ function Popups(){
                         <img src={popupURL} alt={popupNo} />
                     </div>
                     <div className={PPStyle.imagebuttonlayout}>
-                        <Link to={`/user/${popupNo}`} className={PPStyle.imagebuttons}>
+                        <Link to={`/popup-stores/${popupNo}`} className={PPStyle.imagebuttons}>
                             <div>정보</div>
                         </Link>
-                         <Link to={`/user/${popupNo}/review`} className={PPStyle.imagebuttons}>
+                         <Link to={`/popup-stores/${popupNo}/review`} className={PPStyle.imagebuttons}>
                             후기
                         </Link>
                     </div>
@@ -78,7 +78,7 @@ function Popups(){
                     <PopupInfo/>
                     <div className={PPStyle.reviewbtns}>
                         <div>후기</div>
-                        <Link to={`/user/${popupNo}/review`}><div>후기작성하기</div></Link>
+                        <Link to={`/popup-stores/${popupNo}/review`}><div>후기작성하기</div></Link>
                      </div>
                     <ReviewView/>
                     <MidComp1/>

--- a/frontend/src/layouts/userdetail/ReviewInsert.jsx
+++ b/frontend/src/layouts/userdetail/ReviewInsert.jsx
@@ -39,10 +39,10 @@ function ReviewInsert(){
                        <div className="blank"></div>
                        <div className={PPStyle.poster}>이미지준비중</div>
                        <div className={PPStyle.imagebuttonlayout}>
-                           <Link to={`/user/${popupNo}`} className={PPStyle.imagebuttons}>
+                           <Link to={`/popup-stores/${popupNo}`} className={PPStyle.imagebuttons}>
                                정보
                            </Link>
-                           <Link to={`/user/${popupNo}/review`} className={PPStyle.imagebuttons}>
+                           <Link to={`/popup-stores/${popupNo}/review`} className={PPStyle.imagebuttons}>
                                후기
                            </Link>
                        </div>

--- a/frontend/src/layouts/usermain/buttonbar.jsx
+++ b/frontend/src/layouts/usermain/buttonbar.jsx
@@ -35,7 +35,7 @@ function Buttons () {
     return(
         <>
             <div className="buttonbar-layout">
-                <div className="buttonbar"><NavLink to="/user/search" style={{ color: "white", textDecoration: "none" }}>조회</NavLink></div>
+                <div className="buttonbar"><NavLink to="/popup-stores/search" style={{ color: "white", textDecoration: "none" }}>조회</NavLink></div>
                 <Favorite>
                     <div className="buttonbar"><NavLink to="/user/favorite" style={{ color: "white", textDecoration: "none" }}>관심</NavLink></div>
                 </Favorite>


### PR DESCRIPTION

## ✔ 관련 이슈 번호 
#217 
## 📃 작업 상세 내용 
user 페이지 팝업스토어 관련 url user->popup-stores로 수정 상세조회 리뷰 작성 등

## 📸 결과 
검색조회
<img width="1287" height="984" alt="image" src="https://github.com/user-attachments/assets/7c23a6ca-3921-4566-bcc6-c27b5f86c7bc" />
상세조회
<img width="1270" height="986" alt="image" src="https://github.com/user-attachments/assets/9b22a60a-d2b0-4ea2-907b-c99e2b60ac2e" />
리뷰 작성
<img width="1289" height="990" alt="image" src="https://github.com/user-attachments/assets/e3e058ac-8b81-4801-951f-d2993092b80f" />

