### PR TITLE
[FIX] 미승인 팝업스토어 노출 금지 기능 수정

### DIFF
--- a/backend/src/main/resources/mappers/PopupStoreMapper.xml
+++ b/backend/src/main/resources/mappers/PopupStoreMapper.xml
@@ -63,6 +63,7 @@
         hashtag_name
 
         from popup_store
+        where approval_status = "승인"
     </select>
     <select id="selectPopupStoreDetails" resultMap="popupStoreResultMap">
         select
@@ -136,9 +137,6 @@
         <if test="status!=null and status=='done'">
             where popup_end_date &lt; #{endDate}
         </if>
-        <if test="status!=null and status=='all'">
-            where approval_status = "승인"
-        </if>
         and
         (popup_name like concat('%',#{searchWord},'%')
         or brand_name like concat('%',#{searchWord},'%')
@@ -146,6 +144,7 @@
         or hashtag_name like concat('%',#{searchWord},'%')
         or category_name like concat('%',#{searchWord},'%')
         )
+        and approval_status= "승인"
 
     </select>
     <!--검색조회-->

--- a/frontend/src/componenets/user/usersearch/SearchBar.jsx
+++ b/frontend/src/componenets/user/usersearch/SearchBar.jsx
@@ -52,6 +52,7 @@ function SearchBar(){
 
     const onChangeStatus = (e) =>{
         setStatus(e.target.value)
+        console.log(status)
     }
 
     const onCLickSearch = async ()=>{
@@ -88,7 +89,7 @@ function SearchBar(){
             console.log("popups",data)
             setPopups(data)
         })
-    },[searchWord])
+    },[searchWord,status])
 
     
 


### PR DESCRIPTION
## ✔ 관련 이슈 번호 
#245
## 📃 작업 상세 내용 
랜덤 팝업 번호 불러오기 위한 전체 팝업 불러오는 베이스 자체를 승인된 팝업스토어만 조회되도록 쿼리문 수정 
useEffect 의존성 배열에 status 추가하여 오픈 상태에 따른 팝업스토어 검색 조회 시 마다 api 호출 할 수 있도록 수정
## 📸 결과 

쿼리문 수정

<img width="538" height="643" alt="image" src="https://github.com/user-attachments/assets/39a084ac-65c4-4354-8d59-2cc3c2e57c66" />


status 추가

<img width="542" height="141" alt="image" src="https://github.com/user-attachments/assets/c057bb43-0c30-4afa-bfdc-8a2cf1f7879a" />

